### PR TITLE
added: possible fix for x11 error on restart

### DIFF
--- a/files/start.sh
+++ b/files/start.sh
@@ -31,6 +31,11 @@ else
     source ./env2cfg.sh
 fi
 
+echo " "
+echo "Cleaning possible X11 leftovers"
+echo " "
+rm /tmp/.X0-lock
+
 cd "$server_files"
 echo "Starting Foundry Dedicated Server"
 echo " "
@@ -46,4 +51,3 @@ DISPLAY=:0.0 wine /mnt/foundry/server/FoundryDedicatedServer.exe -log 2>&1
 
 # make sure Xvfb process will be stopped and remove lock
 kill $XVFB_PID
-rm /tmp/.X0-lock

--- a/files/start.sh
+++ b/files/start.sh
@@ -31,6 +31,11 @@ else
     source ./env2cfg.sh
 fi
 
+echo " "
+echo "Cleaning possible X11 leftovers"
+echo " "
+rm /tmp/.X0-lock
+
 cd "$server_files"
 echo "Starting Foundry Dedicated Server"
 echo " "

--- a/files/start.sh
+++ b/files/start.sh
@@ -35,6 +35,7 @@ echo " "
 echo "Cleaning possible X11 leftovers"
 echo " "
 rm /tmp/.X0-lock
+rm -r /tmp/*
 
 cd "$server_files"
 echo "Starting Foundry Dedicated Server"

--- a/files/start.sh
+++ b/files/start.sh
@@ -31,16 +31,19 @@ else
     source ./env2cfg.sh
 fi
 
-echo " "
-echo "Cleaning possible X11 leftovers"
-echo " "
-rm /tmp/.X0-lock
-
 cd "$server_files"
 echo "Starting Foundry Dedicated Server"
 echo " "
 echo "Starting Xvfb"
 Xvfb :0 -screen 0 640x480x24:32 &
+
+# save PID of Xvfb process for clean shutdown
+XVFB_PID=$!
+
 echo "Launching wine Foundry"
 echo " "
 DISPLAY=:0.0 wine /mnt/foundry/server/FoundryDedicatedServer.exe -log 2>&1
+
+# make sure Xvfb process will be stopped and remove lock
+kill $XVFB_PID
+rm /tmp/.X0-lock


### PR DESCRIPTION
This is an attempt to fix the "X server is already running" error which sometimes comes up after restart. I am not completely sure as to why this happens, but this fix shouldn't do any harm because we want to start on a "clean state" anyway.