### PR TITLE
Update start.sh

### DIFF
--- a/files/start.sh
+++ b/files/start.sh
@@ -72,6 +72,9 @@ echo " "
 rm /tmp/.X0-lock
 rm -r /tmp/*
 
+# add Mods folder for future use
+mkdir -p "$server_files/Mods" 2>/dev/null
+
 cd "$server_files"
 echo "Starting Foundry Dedicated Server"
 echo " "


### PR DESCRIPTION
add Mods folder for future use. both server and dev call for it

when Mods folder is installed:
`Loading Mods from: Z:\mnt\foundry\server\Mods`

when it is not added. (why its not added in the default install ill never know)
`Could not find mod directory: Mods`