### PR TITLE
Apply PUID/PGID at runtime to fix volume file ownership

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,13 +27,14 @@ RUN apt-get update && \
 RUN echo 'export LC_ALL=$LC_ALL' >> /etc/profile.d/locale.sh && \
     sed -i 's|LANG=C.UTF-8|LANG=$LANG|' /etc/profile.d/locale.sh
 
-# add new user
-RUN groupadd -g ${PGUID:-1000} $USER && \
-    useradd -d $HOME -u ${PUID:-1000} -g $USER $USER && \
+# add new user (default ids; the real PUID/PGID are applied at runtime in entrypoint.sh)
+RUN groupadd -g 1000 $USER && \
+    useradd -d $HOME -u 1000 -g $USER $USER && \
     mkdir -p $HOME && \
     chown $USER:$USER $HOME
 
-RUN echo "$USER ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/$USER && \
+# SETENV lets the entrypoint re-exec via `sudo -E` while preserving env vars
+RUN echo "$USER ALL=(ALL) NOPASSWD:SETENV: ALL" > /etc/sudoers.d/$USER && \
     chmod 0440 /etc/sudoers.d/$USER
 
 USER $USER

--- a/files/entrypoint.sh
+++ b/files/entrypoint.sh
@@ -1,5 +1,30 @@
 #!/bin/bash
 
+# Apply PUID/PGID at runtime so files written to the mounted volumes are
+# owned by the user/group the host expects. Defaults to 1000:1000.
+PUID=${PUID:-1000}
+PGID=${PGID:-1000}
+
+current_uid=$(id -u foundry)
+current_gid=$(getent group foundry | cut -d: -f3)
+
+if [ "$PGID" != "$current_gid" ]; then
+    echo "Updating foundry group id: $current_gid -> $PGID"
+    sudo groupmod -o -g "$PGID" foundry
+fi
+
+if [ "$PUID" != "$current_uid" ]; then
+    echo "Updating foundry user id: $current_uid -> $PUID"
+    sudo usermod -o -u "$PUID" foundry
+fi
+
 # To be able to use the volumes user foundry needs access
-sudo -u root chown -R foundry:foundry /home/foundry
-exec "$@"
+sudo chown -R foundry:foundry /home/foundry
+
+# If the IDs were remapped, the current process still runs under the old UID,
+# so re-exec the command as the updated foundry user.
+if [ "$PUID" != "$current_uid" ] || [ "$PGID" != "$current_gid" ]; then
+    exec sudo -E -u foundry "$@"
+else
+    exec "$@"
+fi


### PR DESCRIPTION
Honor PUID/PGID env vars in entrypoint via usermod/groupmod instead of baking fixed ids at build time, so files on mounted volumes get the expected owner.

This fixes #28.